### PR TITLE
Allow for force creation if needed

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -37,7 +37,7 @@ class Event
             $event->$name = $value;
         }
 
-        return $event->save();
+        return $event->save(true);
     }
 
     public function __construct()
@@ -137,9 +137,14 @@ class Event
         return static::createFromGoogleCalendarEvent($googleEvent, $calendarId);
     }
 
-    public function save(): Event
+    public function save($forceCreate = false): Event
     {
         $method = $this->exists() ? 'updateEvent' : 'insertEvent';
+        
+        if($forceCreate)
+        {
+            $method = 'insertEvent';
+        }
 
         $googleCalendar = $this->getGoogleCalendar($this->calendarId);
 


### PR DESCRIPTION
In case you need to provide your own event ID, the exists() method switches from creation to update. 
More on this problem in issue #12.