### PR TITLE
use static call for consistency

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -114,7 +114,7 @@ class Event
 
         return collect($googleEvents)
             ->map(function (Google_Service_Calendar_Event $event) use ($calendarId) {
-                return Event::createFromGoogleCalendarEvent($event, $calendarId);
+                return static::createFromGoogleCalendarEvent($event, $calendarId);
             })
             ->sortBy(function (Event $event) {
                 return $event->sortDate;


### PR DESCRIPTION
All calls on the `Event` class were using `static::`, but not this particular one. I PR'd this for consistency.