### PR TITLE
Upgrade to use Google API v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Spatie\\GoogleCalendar\\Test\\": "tests"
+            "Spatie\\GoogleCalendar\\Tests\\": "tests"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "google/apiclient": "^2.0",
+        "google/apiclient": "^2.2",
         "illuminate/support": "^5.4.0",
         "nesbot/carbon": "^1.21"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "google/apiclient": "^1.1.7",
-        "illuminate/support": "^5.2.8",
+        "php": "^7.0",
+        "google/apiclient": "^2.0",
+        "illuminate/support": "^5.4.0",
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.3.4",
-        "orchestra/testbench": "^3.2",
-        "mockery/mockery": "^0.9.5"
+        "mockery/mockery": "^0.9.5",
+        "orchestra/testbench": "~3.4.6",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/laravel-google-calendar.php
+++ b/config/laravel-google-calendar.php
@@ -3,13 +3,13 @@
 return [
 
     /*
-     * Path to a json file containing the credentials of a Google Service account.
+     * Path to the client secret json file.
      */
-    'client_secret_json' => storage_path('app/laravel-google-calendar/client_secret.json'),
+    'service_account_credentials_json' => storage_path('app/google-calendar/service-account-credentials.json'),
 
     /*
      *  The id of the Google Calendar that will be used by default.
      */
-    'calendar_id' => '',
+    'calendar_id' => env('GOOGLE_CALENDAR_ID'),
 
 ];

--- a/src/Event.php
+++ b/src/Event.php
@@ -16,7 +16,7 @@ class Event
     public $googleEvent;
 
     /**
-     * @var int
+     * @var string
      */
     protected $calendarId;
 
@@ -42,7 +42,6 @@ class Event
         $event = new static;
 
         $event->googleEvent = $googleEvent;
-
         $event->calendarId = $calendarId;
 
         return $event;

--- a/src/Event.php
+++ b/src/Event.php
@@ -2,25 +2,44 @@
 
 namespace Spatie\GoogleCalendar;
 
-use DateTime;
 use Carbon\Carbon;
+use DateTime;
 use Google_Service_Calendar_Event;
-use Illuminate\Support\Collection;
 use Google_Service_Calendar_EventDateTime;
+use Illuminate\Support\Collection;
 
 class Event
 {
-    /** @var \Google_Service_Calendar_Event */
+    /**
+     * @var \Google_Service_Calendar_Event
+     */
     public $googleEvent;
 
-    /** @var int */
+    /**
+     * @var int
+     */
     protected $calendarId;
 
+    /**
+     * @var array
+     */
     protected $attendees;
 
+    public function __construct()
+    {
+        $this->attendees = [];
+        $this->googleEvent = new Google_Service_Calendar_Event;
+    }
+
+    /**
+     * @param \Google_Service_Calendar_Event $googleEvent
+     * @param $calendarId
+     *
+     * @return static
+     */
     public static function createFromGoogleCalendarEvent(Google_Service_Calendar_Event $googleEvent, $calendarId)
     {
-        $event = new static();
+        $event = new static;
 
         $event->googleEvent = $googleEvent;
 
@@ -29,9 +48,15 @@ class Event
         return $event;
     }
 
+    /**
+     * @param array $properties
+     * @param string|null $calendarId
+     *
+     * @return mixed
+     */
     public static function create(array $properties, string $calendarId = null)
     {
-        $event = new static();
+        $event = new static;
 
         $event->calendarId = static::getGoogleCalendar($calendarId)->getCalendarId();
 
@@ -42,10 +67,43 @@ class Event
         return $event->save('insertEvent');
     }
 
-    public function __construct()
+    /**
+     * @param \Carbon\Carbon|null $startDateTime
+     * @param \Carbon\Carbon|null $endDateTime
+     * @param array $queryParameters
+     * @param string|null $calendarId
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public static function get(Carbon $startDateTime = null, Carbon $endDateTime = null, array $queryParameters = [], string $calendarId = null) : Collection
     {
-        $this->attendees = [];
-        $this->googleEvent = new Google_Service_Calendar_Event();
+        $googleCalendar = static::getGoogleCalendar($calendarId);
+
+        $googleEvents = $googleCalendar->listEvents($startDateTime, $endDateTime, $queryParameters);
+
+        return collect($googleEvents)
+            ->map(function (Google_Service_Calendar_Event $event) use ($calendarId) {
+                return static::createFromGoogleCalendarEvent($event, $calendarId);
+            })
+            ->sortBy(function (Event $event) {
+                return $event->sortDate;
+            })
+            ->values();
+    }
+
+    /**
+     * @param string $eventId
+     * @param string $calendarId
+     *
+     * @return \Spatie\GoogleCalendar\Event
+     */
+    public static function find($eventId, $calendarId = null) : Event
+    {
+        $googleCalendar = static::getGoogleCalendar($calendarId);
+
+        $googleEvent = $googleCalendar->getEvent($eventId);
+
+        return static::createFromGoogleCalendarEvent($googleEvent, $calendarId);
     }
 
     /**
@@ -74,6 +132,10 @@ class Event
         return $value;
     }
 
+    /**
+     * @param $name
+     * @param $value
+     */
     public function __set($name, $value)
     {
         $name = $this->getFieldName($name);
@@ -87,60 +149,28 @@ class Event
         array_set($this->googleEvent, $name, $value);
     }
 
-    public function exists(): bool
+    /**
+     * @return bool
+     */
+    public function exists() : bool
     {
         return $this->id != '';
     }
 
-    public function isAllDayEvent(): bool
+    /**
+     * @return bool
+     */
+    public function isAllDayEvent() : bool
     {
         return is_null($this->googleEvent['start']['dateTime']);
     }
 
     /**
-     * @param \Carbon\Carbon|null $startDateTime
-     * @param \Carbon\Carbon|null $endDateTime
-     * @param array               $queryParameters
-     * @param string|null         $calendarId
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public static function get(
-        Carbon $startDateTime = null,
-        Carbon $endDateTime = null,
-        array $queryParameters = [],
-        string $calendarId = null
-    ): Collection {
-        $googleCalendar = static::getGoogleCalendar($calendarId);
-
-        $googleEvents = $googleCalendar->listEvents($startDateTime, $endDateTime, $queryParameters);
-
-        return collect($googleEvents)
-            ->map(function (Google_Service_Calendar_Event $event) use ($calendarId) {
-                return static::createFromGoogleCalendarEvent($event, $calendarId);
-            })
-            ->sortBy(function (Event $event) {
-                return $event->sortDate;
-            })
-            ->values();
-    }
-
-    /**
-     * @param string $eventId
-     * @param string $calendarId
+     * @param null $method
      *
      * @return \Spatie\GoogleCalendar\Event
      */
-    public static function find($eventId, $calendarId = null): Event
-    {
-        $googleCalendar = static::getGoogleCalendar($calendarId);
-
-        $googleEvent = $googleCalendar->getEvent($eventId);
-
-        return static::createFromGoogleCalendarEvent($googleEvent, $calendarId);
-    }
-
-    public function save($method = null): Event
+    public function save($method = null) : Event
     {
         $method = $method ?? ($this->exists() ? 'updateEvent' : 'insertEvent');
 
@@ -162,6 +192,30 @@ class Event
     }
 
     /**
+     * @param array $attendees
+     */
+    public function addAttendee(array $attendees)
+    {
+        $this->attendees[] = $attendees;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSortDate() : string
+    {
+        if ($this->startDate) {
+            return $this->startDate;
+        }
+
+        if ($this->startDateTime) {
+            return $this->startDateTime;
+        }
+
+        return '';
+    }
+
+    /**
      * @param string $calendarId
      *
      * @return \Spatie\GoogleCalendar\GoogleCalendar
@@ -174,12 +228,12 @@ class Event
     }
 
     /**
-     * @param string         $name
+     * @param string $name
      * @param \Carbon\Carbon $date
      */
     protected function setDateProperty(string $name, Carbon $date)
     {
-        $eventDateTime = new Google_Service_Calendar_EventDateTime();
+        $eventDateTime = new Google_Service_Calendar_EventDateTime;
 
         if (in_array($name, ['start.date', 'end.date'])) {
             $eventDateTime->setDate($date->format('Y-m-d'));
@@ -200,33 +254,20 @@ class Event
         }
     }
 
-    public function addAttendee(array $attendees)
-    {
-        $this->attendees[] = $attendees;
-    }
-
-    protected function getFieldName(string $name): string
+    /**
+     * @param string $name
+     *
+     * @return string
+     */
+    protected function getFieldName(string $name) : string
     {
         return [
-            'name'          => 'summary',
-            'description'   => 'description',
-            'startDate'     => 'start.date',
-            'endDate'       => 'end.date',
-            'startDateTime' => 'start.dateTime',
-            'endDateTime'   => 'end.dateTime',
-        ][$name] ?? $name;
-    }
-
-    public function getSortDate(): string
-    {
-        if ($this->startDate) {
-            return $this->startDate;
-        }
-
-        if ($this->startDateTime) {
-            return $this->startDateTime;
-        }
-
-        return '';
+                   'name' => 'summary',
+                   'description' => 'description',
+                   'startDate' => 'start.date',
+                   'endDate' => 'end.date',
+                   'startDateTime' => 'start.dateTime',
+                   'endDateTime' => 'end.dateTime',
+               ][$name] ?? $name;
     }
 }

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\GoogleCalendar\Exceptions;
+
+use Exception;
+
+class InvalidConfiguration extends Exception
+{
+    public static function calendarIdNotSpecified()
+    {
+        return new static('There was no calendar id specified. You must provide a valid calendar id to fetch events for.');
+    }
+
+    public static function credentialsJsonDoesNotExist(string $path)
+    {
+        return new static("Could not find a credentials file at `{$path}`.");
+    }
+}

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -2,19 +2,27 @@
 
 namespace Spatie\GoogleCalendar;
 
-use DateTime;
 use Carbon\Carbon;
+use DateTime;
 use Google_Service_Calendar;
 use Google_Service_Calendar_Event;
 
 class GoogleCalendar
 {
-    /** @var \Google_Service_Calendar */
+    /**
+     * @var \Google_Service_Calendar
+     */
     protected $calendarService;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $calendarId;
 
+    /**
+     * @param \Google_Service_Calendar $calendarService
+     * @param $calendarId
+     */
     public function __construct(Google_Service_Calendar $calendarService, $calendarId)
     {
         $this->calendarService = $calendarService;
@@ -22,7 +30,10 @@ class GoogleCalendar
         $this->calendarId = $calendarId;
     }
 
-    public function getCalendarId(): string
+    /**
+     * @return string
+     */
+    public function getCalendarId() : string
     {
         return $this->calendarId;
     }
@@ -30,17 +41,14 @@ class GoogleCalendar
     /**
      * @param \Carbon\Carbon $startDateTime
      * @param \Carbon\Carbon $endDateTime
-     * @param array          $queryParameters
+     * @param array $queryParameters
      *
      * @link https://developers.google.com/google-apps/calendar/v3/reference/events/list
      *
      * @return array
      */
-    public function listEvents(
-        Carbon $startDateTime = null,
-        Carbon $endDateTime = null,
-        array $queryParameters = []
-    ): array {
+    public function listEvents(Carbon $startDateTime = null, Carbon $endDateTime = null, array $queryParameters = []) : array
+    {
         $parameters = ['singleEvents' => true];
 
         if (is_null($startDateTime)) {
@@ -70,7 +78,7 @@ class GoogleCalendar
      *
      * @return \Google_Service_Calendar_Event
      */
-    public function getEvent(string $eventId): Google_Service_Calendar_Event
+    public function getEvent(string $eventId) : Google_Service_Calendar_Event
     {
         return $this->calendarService->events->get($this->calendarId, $eventId);
     }
@@ -84,7 +92,7 @@ class GoogleCalendar
      *
      * @return \Google_Service_Calendar_Event
      */
-    public function insertEvent($event): Google_Service_Calendar_Event
+    public function insertEvent($event) : Google_Service_Calendar_Event
     {
         if ($event instanceof Event) {
             $event = $event->googleEvent;
@@ -98,7 +106,7 @@ class GoogleCalendar
      *
      * @return \Google_Service_Calendar_Event
      */
-    public function updateEvent($event): Google_Service_Calendar_Event
+    public function updateEvent($event) : Google_Service_Calendar_Event
     {
         if ($event instanceof Event) {
             $event = $event->googleEvent;
@@ -119,7 +127,10 @@ class GoogleCalendar
         $this->calendarService->events->delete($this->calendarId, $eventId);
     }
 
-    public function getService(): Google_Service_Calendar
+    /**
+     * @return \Google_Service_Calendar
+     */
+    public function getService() : Google_Service_Calendar
     {
         return $this->calendarService;
     }

--- a/src/GoogleCalendarFacade.php
+++ b/src/GoogleCalendarFacade.php
@@ -4,9 +4,6 @@ namespace Spatie\GoogleCalendar;
 
 use Illuminate\Support\Facades\Facade;
 
-/**
- * @see \Spatie\GoogleCalendar\GoogleCalendar
- */
 class GoogleCalendarFacade extends Facade
 {
     /**

--- a/src/GoogleCalendarFactory.php
+++ b/src/GoogleCalendarFactory.php
@@ -7,21 +7,48 @@ use Google_Service_Calendar;
 
 class GoogleCalendarFactory
 {
-    public static function createForCalendarId($calendarId): GoogleCalendar
+    /**
+     * @param string $calendarId
+     *
+     * @return \Spatie\GoogleCalendar\GoogleCalendar
+     */
+    public static function createForCalendarId(string $calendarId) : GoogleCalendar
     {
         $config = config('laravel-google-calendar');
 
-        $client = new Google_Client();
-
-        $credentials = $client->loadServiceAccountJson(
-            $config['client_secret_json'],
-            'https://www.googleapis.com/auth/calendar'
-        );
-
-        $client->setAssertionCredentials($credentials);
+        $client = self::createAuthenticatedGoogleClient($config);
 
         $service = new Google_Service_Calendar($client);
 
+        return self::createCalendarClient($service, $calendarId);
+    }
+
+    /**
+     * @param array $config
+     *
+     * @return \Google_Client
+     */
+    public static function createAuthenticatedGoogleClient(array $config) : Google_Client
+    {
+        $client = new Google_Client;
+
+        $client->setScopes([
+            Google_Service_Calendar::CALENDAR,
+        ]);
+
+        $client->setAuthConfig($config['service_account_credentials_json']);
+
+        return $client;
+    }
+
+    /**
+     * @param \Google_Service_Calendar $service
+     * @param string $calendarId
+     *
+     * @return \Spatie\GoogleCalendar\GoogleCalendar
+     */
+    protected static function createCalendarClient(Google_Service_Calendar $service, string $calendarId) : GoogleCalendar
+    {
         return new GoogleCalendar($service, $calendarId);
     }
 }

--- a/src/GoogleCalendarServiceProvider.php
+++ b/src/GoogleCalendarServiceProvider.php
@@ -24,11 +24,11 @@ class GoogleCalendarServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/laravel-google-calendar.php', 'laravel-google-calendar');
 
-        $config = config('laravel-google-calendar');
+        $this->app->bind(GoogleCalendar::class, function () {
+            $config = config('laravel-google-calendar');
 
-        $this->guardAgainstInvalidConfiguration($config);
+            $this->guardAgainstInvalidConfiguration($config);
 
-        $this->app->bind(GoogleCalendar::class, function () use ($config) {
             return GoogleCalendarFactory::createForCalendarId($config['calendar_id']);
         });
 

--- a/tests/Integration/EventTest.php
+++ b/tests/Integration/EventTest.php
@@ -22,12 +22,6 @@ class EventTest extends TestCase
     }
 
     /** @test */
-    public function it_will_use_the_calendar_id_from_the_config_file_by_default()
-    {
-        $this->assertEquals($this->calenderId, $this->event->calendarId);
-    }
-
-    /** @test */
     public function it_can_set_a_start_date()
     {
         $now = Carbon::now();

--- a/tests/Integration/EventTest.php
+++ b/tests/Integration/EventTest.php
@@ -1,23 +1,24 @@
 <?php
 
-namespace Spatie\GoogleCalendar\Test;
+namespace Spatie\GoogleCalendar\Tests\Integration;
 
-use Mockery;
-use DateTime;
 use Carbon\Carbon;
+use DateTime;
 use Spatie\GoogleCalendar\Event;
-use Spatie\GoogleCalendar\Test\Integration\TestCase;
+use Spatie\GoogleCalendar\Tests\TestCase;
 
 class EventTest extends TestCase
 {
-    /** @var \Spatie\GoogleCalendar\Event|Mockery\Mock */
+    /**
+     * @var \Spatie\GoogleCalendar\Event
+     */
     protected $event;
 
     public function setUp()
     {
         parent::setUp();
 
-        $this->event = new Event();
+        $this->event = new Event;
     }
 
     /** @test */
@@ -73,7 +74,7 @@ class EventTest extends TestCase
     {
         $now = Carbon::now();
 
-        $event = new Event();
+        $event = new Event;
 
         $this->assertEmpty($event->getSortDate());
 
@@ -101,7 +102,7 @@ class EventTest extends TestCase
     /** @test */
     public function it_can_determine_if_an_event_is_an_all_day_event()
     {
-        $event = new Event();
+        $event = new Event;
 
         $event->startDate = Carbon::now();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,13 +1,18 @@
 <?php
 
-namespace Spatie\GoogleCalendar\Test\Integration;
+namespace Spatie\GoogleCalendar\Tests;
 
-use Orchestra\Testbench\TestCase as Orchestra;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Spatie\GoogleCalendar\GoogleCalendarServiceProvider;
 
-abstract class TestCase extends Orchestra
+abstract class TestCase extends OrchestraTestCase
 {
-    /** @var string */
+    use MockeryPHPUnitIntegration;
+
+    /**
+     * @var string
+     */
     protected $calenderId;
 
     public function setUp()
@@ -22,7 +27,7 @@ abstract class TestCase extends Orchestra
      *
      * @return array
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app) : array
     {
         return [
             GoogleCalendarServiceProvider::class,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,17 +28,10 @@ abstract class TestCase extends OrchestraTestCase
     }
 
     /**
-     * Resolve application core configuration implementation.
+     * Define environment setup.
      *
      * @param \Illuminate\Foundation\Application $app
-     *
-     * @return void
      */
-    protected function resolveApplicationConfiguration($app)
-    {
-        parent::resolveApplicationConfiguration($app);
-    }
-
     protected function getEnvironmentSetUp($app)
     {
         $app['config']->set('laravel-google-calendar.calendar_id', $this->calendarId = 'personal');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,14 +13,7 @@ abstract class TestCase extends OrchestraTestCase
     /**
      * @var string
      */
-    protected $calenderId;
-
-    public function setUp()
-    {
-        $this->calendarId = 'abc123';
-
-        parent::setUp();
-    }
+    protected $calendarId;
 
     /**
      * @param \Illuminate\Foundation\Application $app
@@ -35,10 +28,19 @@ abstract class TestCase extends OrchestraTestCase
     }
 
     /**
+     * Resolve application core configuration implementation.
+     *
      * @param \Illuminate\Foundation\Application $app
+     *
+     * @return void
      */
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+    }
+
     protected function getEnvironmentSetUp($app)
     {
-        $app['config']->set('laravel-google-calendar.calendar_id', 'sqlite');
+        $app['config']->set('laravel-google-calendar.calendar_id', $this->calendarId = 'personal');
     }
 }

--- a/tests/Unit/GoogleCalendarTest.php
+++ b/tests/Unit/GoogleCalendarTest.php
@@ -1,20 +1,27 @@
 <?php
 
-namespace Spatie\GoogleCalendar\Test\Unit;
+namespace Spatie\GoogleCalendar\Tests\Unit;
 
-use Mockery;
 use Google_Service_Calendar;
+use Mockery;
+use PHPUnit\Framework\TestCase;
 use Spatie\GoogleCalendar\GoogleCalendar;
 
-class GoogleCalendarTest extends \PHPUnit_Framework_TestCase
+class GoogleCalendarTest extends TestCase
 {
-    /** @var \Mockery\Mock|Google_Service_Calendar */
+    /**
+     * @var \Mockery\Mock|Google_Service_Calendar
+     */
     protected $googleServiceCalendar;
 
-    /** @var string */
+    /**
+     * @var string
+     */
     protected $calendarId;
 
-    /** @var \Spatie\GoogleCalendar\GoogleCalendar */
+    /**
+     * @var \Spatie\GoogleCalendar\GoogleCalendar
+     */
     protected $googleCalendar;
 
     public function setUp()


### PR DESCRIPTION
PR to upgrade to `"google/apiclient": "^2.2",`, which allows to use both spatie/laravel-analytics and spatie/laravel-google-calendar in a single project.

Will probably require some more tests, code formatting, … but it works :)

## Notes

- Haven't tested creating events, only fetching them from different calendars. But nothing much has changed (just how authentication happens in the factory), so probably still works.
- Copied some stuff from your analytics package that seemed useful (guard against invalid config, etc)
- Upgraded PHPUnit and other packages while I was at it
- Fixed a typo which also lead to the discovery of a test bug (asserting `null` equals `null` instead of the actual calendar ID, so in effect, the test actually failed).
    - I removed the `it_will_use_the_calendar_id_from_the_config_file_by_default` test completely. Not sure what to do with it since testing this would require either actual Google API credentials or some research to see if the Google event class still returns the `calendarId` key (which gets passed to it through Spatie's event class).
- Most file diffs / changes are from PHPStorm applying my code formatting. Most changes where done in the factory and a few in the service provider and config. Can either leave this as-is or start over and copy changes, but use a different code style.