### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": "^7.0",
         "google/apiclient": "^2.2",
-        "illuminate/support": "^5.4.0",
+        "illuminate/support": "^5.4.0|~5.5.x-dev",
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "orchestra/testbench": "~3.4.6",
+        "orchestra/testbench": "~3.4.6|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "php": "^7.0",
         "google/apiclient": "^2.2",
-        "illuminate/support": "^5.4.0|~5.5.x-dev",
+        "illuminate/support": "^5.4.0|~5.5.x-dev|~5.5.x-dev",
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "orchestra/testbench": "~3.4.6|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.6|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -57,3 +57,4 @@
         "sort-packages": true
     }
 }
+


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-google-calendar/phpunit.xml.dist

.........                                                           9 / 9 (100%)

Time: 5.08 seconds, Memory: 12.00MB

OK (9 tests, 12 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments