### PR TITLE
Don't reorder event list if user has provided 'orderBy' parameter. Resolves #49

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -76,6 +76,7 @@ class Event
                 if ($useUserOrder) {
                     return $index;
                 }
+
                 return $event->sortDate;
             })
             ->values();

--- a/src/Event.php
+++ b/src/Event.php
@@ -66,11 +66,16 @@ class Event
 
         $googleEvents = $googleCalendar->listEvents($startDateTime, $endDateTime, $queryParameters);
 
+        $useUserOrder = isset($queryParameters['orderBy']);
+
         return collect($googleEvents)
             ->map(function (Google_Service_Calendar_Event $event) use ($calendarId) {
                 return static::createFromGoogleCalendarEvent($event, $calendarId);
             })
-            ->sortBy(function (Event $event) {
+            ->sortBy(function (Event $event, $index) use ($useUserOrder) {
+                if ($useUserOrder) {
+                    return $index;
+                }
                 return $event->sortDate;
             })
             ->values();


### PR DESCRIPTION
Currently event list is always ordered by `$event->sortDate`. Now the list will be returned without sorting (in google returned order) if user has provided `orderBy` parameter.

Tests not added as this change requires actual connection to google calendar.
Tested in other project which uses this package.