### PR TITLE
add abilities to add query params

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -135,7 +135,7 @@ class Event
         return is_null($this->googleEvent['start']['dateTime']);
     }
 
-    public function save(string $method = null): Event
+    public function save(string $method = null, $optParams = []): Event
     {
         $method = $method ?? ($this->exists() ? 'updateEvent' : 'insertEvent');
 
@@ -143,7 +143,7 @@ class Event
 
         $this->googleEvent->setAttendees($this->attendees);
 
-        $googleEvent = $googleCalendar->$method($this);
+        $googleEvent = $googleCalendar->$method($this, $optParams);
 
         return static::createFromGoogleCalendarEvent($googleEvent, $googleCalendar->getCalendarId());
     }

--- a/src/Event.php
+++ b/src/Event.php
@@ -47,7 +47,7 @@ class Event
      *
      * @return mixed
      */
-    public static function create(array $properties, string $calendarId = null)
+    public static function create(array $properties, string $calendarId = null, $optParams = [])
     {
         $event = new static;
 
@@ -57,7 +57,7 @@ class Event
             $event->$name = $value;
         }
 
-        return $event->save('insertEvent');
+        return $event->save('insertEvent', $optParams);
     }
 
     public static function get(Carbon $startDateTime = null, Carbon $endDateTime = null, array $queryParameters = [], string $calendarId = null) : Collection
@@ -148,13 +148,13 @@ class Event
         return static::createFromGoogleCalendarEvent($googleEvent, $googleCalendar->getCalendarId());
     }
 
-    public function update(array $attributes): Event
+    public function update(array $attributes, $optParams = []): Event
     {
         foreach ($attributes as $name => $value) {
             $this->$name = $value;
         }
 
-        return $this->save('updateEvent');
+        return $this->save('updateEvent', $optParams);
     }
 
     public function delete(string $eventId = null)

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -62,13 +62,13 @@ class GoogleCalendar
     /*
      * @link https://developers.google.com/google-apps/calendar/v3/reference/events/insert
      */
-    public function insertEvent($event): Google_Service_Calendar_Event
+    public function insertEvent($event, $optParams = []): Google_Service_Calendar_Event
     {
         if ($event instanceof Event) {
             $event = $event->googleEvent;
         }
 
-        return $this->calendarService->events->insert($this->calendarId, $event);
+        return $this->calendarService->events->insert($this->calendarId, $event, $optParams);
     }
 
     public function updateEvent($event): Google_Service_Calendar_Event


### PR DESCRIPTION
Google API calendar supports some query parameters like sendNotifications. ref: https://developers.google.com/google-apps/calendar/v3/reference/events/insert

We should be able to use it:

```
$event = new Event;
...
$event->save('insertEvent', ['sendNotifications' => true]);
```