### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nesbot/carbon": "^1.21"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.4.6",
         "phpunit/phpunit": "^6.2"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).