### PR TITLE
First draft of sending multiple requests as a batch

### DIFF
--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -74,6 +74,8 @@ class GoogleCalendar
 
     public function getEvents(iterable $eventIds, $optParams = [])
     {
+        $this->enableBatch(true);
+
         collect($eventIds)
             ->each(
                 function ($eventId, $batchIdentifier) use ($optParams) {
@@ -101,6 +103,8 @@ class GoogleCalendar
 
     public function insertEvents(iterable $events, $optParams = [])
     {
+        $this->enableBatch(true);
+
         collect($events)
             ->each(
                 function ($event, $batchIdentifier) use ($optParams) {
@@ -127,6 +131,8 @@ class GoogleCalendar
 
     public function updateEvents(iterable $events, $optParams = [])
     {
+        $this->enableBatch(true);
+
         collect($events)
             ->each(
                 function ($event, $batchIdentifier) use ($optParams) {
@@ -159,6 +165,8 @@ class GoogleCalendar
      */
     public function deleteEvents(iterable $eventIds, $optParams = [])
     {
+        $this->enableBatch(true);
+
         collect($eventIds)
             ->each(
                 function ($eventId, $batchIdentifier) use ($optParams) {
@@ -173,7 +181,7 @@ class GoogleCalendar
         return $this->calendarService;
     }
 
-    public function enableBatch(bool $bool)
+    protected function enableBatch(bool $bool)
     {
         $this->calendarService->getClient()->setUseBatch($bool);
 

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -79,7 +79,7 @@ class GoogleCalendar
         collect($eventIds)
             ->each(
                 function ($eventId, $batchIdentifier) use ($optParams) {
-                    $this->batchRequests->add($this->getEvent($eventId, $optParams), $batchIdentifier);
+                    $this->batchRequests->add($this->getEvent($eventId, $optParams), "get-".$batchIdentifier);
                 });
 
         return $this;
@@ -108,7 +108,7 @@ class GoogleCalendar
         collect($events)
             ->each(
                 function ($event, $batchIdentifier) use ($optParams) {
-                    $this->batchRequests->add($this->insertEvent($event, $optParams), $batchIdentifier);
+                    $this->batchRequests->add($this->insertEvent($event, $optParams), "insert-".$batchIdentifier);
                 });
 
         return $this;
@@ -136,7 +136,7 @@ class GoogleCalendar
         collect($events)
             ->each(
                 function ($event, $batchIdentifier) use ($optParams) {
-                    $this->batchRequests->add($this->updateEvent($event, $optParams), $batchIdentifier);
+                    $this->batchRequests->add($this->updateEvent($event, $optParams), "update-".$batchIdentifier);
                 });
 
         return $this;
@@ -170,7 +170,7 @@ class GoogleCalendar
         collect($eventIds)
             ->each(
                 function ($eventId, $batchIdentifier) use ($optParams) {
-                    $this->batchRequests->add($this->deleteEvent($eventId, $optParams), $batchIdentifier);
+                    $this->batchRequests->add($this->deleteEvent($eventId, $optParams), "delete-".$batchIdentifier);
                 });
 
         return $this;

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -148,7 +148,7 @@ class GoogleCalendar
      *
      * @return RequestInterface
      */
-    public function deleteEvent($eventId,  $optParams = [])
+    public function deleteEvent($eventId, $optParams = [])
     {
         if ($eventId instanceof Event) {
             $eventId = $eventId->id;

--- a/tests/Unit/GoogleCalendarTest.php
+++ b/tests/Unit/GoogleCalendarTest.php
@@ -23,6 +23,7 @@ class GoogleCalendarTest extends TestCase
         parent::setUp();
 
         $this->googleServiceCalendar = Mockery::mock(Google_Service_Calendar::class);
+        $this->googleServiceCalendar->shouldReceive('createBatch')->once();
 
         $this->calendarId = 'abc123';
 


### PR DESCRIPTION
Hi @freekmurze,

As per the tweet I sent you the other day, I was wondering if this was a good time to propose a fairly significant feature for this calendar package.

The current package sends a request to the Google servers for every insert/update/get/delete request that a user makes when creating/changing an event on their calendar. This is fine when you are working on a small number of events, but I don't think it scales very well and is a little bit heavy handed with hitting the Google servers.

There is a feature with the API that allows us to BATCH SEND a request that holds up to 50 calls per single request (https://developers.google.com/calendar/batch#overview). I will deliberately ignore this limit at the moment in this PR, but it is trivial to work with later.

I currently have a webapp that (sometimes) requires up to 300-500 events to be added to a calendar in one go. Sending each of those as an individual http request would really slow it down and also I don't want to be hitting google's servers so much in a short period of time.

So I've attempted to add some features to your current package to allow a user to send many requests using the BATCH facility in the google api library.

https://developers.google.com/api-client-library/php/guide/batch


Here's where I need your help! I'm not sure how you would like this to look, there are some options I would like to hear your feedback on.

1) At the moment I have only ADDED methods to the Google Calendar class and so this *should* be backwards compatible.

~~2) My BIG problem is that to make the BATCH feature work, it must be "switched on" before the first request is generated. My current implementaion is to add an `enableBatch($bool)` method. I don't really like the way this looks in the code - I would love to get feedback on how else this could be done.~~

3) When the batch feature is "switched on" - all the current methods return an http request object that implements the `\Psr\Http\Message\RequestInterface` and not a `Google_Service_Calendar_Event`. I therefore had to remove the return type hinting in the methods on the calendar class. Can you specify two types of return objects from a method? I don't think so??

4) Anyone who needs to add/edit/remove a SINGLE event at a time can still use the current methods/code that they have.

5) This doesn't change anything for those who want to use the Event::<action> way at the moment. Those single requests will still be sent individually.

6) Anyone who would like to "store up" all the changes/additions/deletions they are going to make into a batch request can use 
these new addition methods.

The outline of the calendar class with new methods marked with a * would be as follows:

```
listEvents
getEvent
getEvents*
insertEvent
insertEvents*
updateEvent
updateEvents*
deleteEvent
deleteEvents*
```

Some code to show how this would look:

```php

//Create some events to use later
    $event1 = new \Spatie\GoogleCalendar\Event;
    $event1->name = 'Event 1';
    $event1->startDateTime = \Carbon\Carbon::parse('2018-08-23 12:00');
    $event1->endDateTime = \Carbon\Carbon::parse('2018-08-23 13:00');

    $event2 = new \Spatie\GoogleCalendar\Event;
    $event2->name = 'Event 2';
    $event2->startDateTime = \Carbon\Carbon::parse('2018-08-23 16:00');
    $event2->endDateTime = \Carbon\Carbon::parse('2018-08-23 17:00');


//Currently you can do this - I appreciate this is not the most streamlined, only to prove the point:

    $calendar = app('laravel-google-calendar');

    $inserted1 = $calendar->insertEvent($event1);
    $inserted2 = $calendar->insertEvent($event2);


    $event3 = $calendar->getEvent('abcdefg');
    $event4 = $calendar->getEvent('hijklmn');
    $event5 = $calendar->getEvent('opqrstu');


    $updated = $calendar->updateEvent($event1);

    $calendar->deleteEvent('abcdefg');


//This is a total of 7 http requests.




//Proposed


    $response = $calendar
        ->getEvents(['abcedfg', 'hijklmn', 'opqrstu',])
        ->insertEvents([$event1, $event2])
        ->updateEvents([$event1])
        ->deleteEvents(['abcedfg',])
        ->sendBatch();

        //This is a total of ONE http request. It's VERY fast :)

```


The proposed way would allow ALL of those requests to be sent in ONE http request rather than a single one.


7) Like the `enableBatch` method at the start, the batch feature would require the user to end their requests with the `->sendBatch()` method. What are your thoughts about that? Is the name acceptable? Is there a better way?

8) The batch request that gets sent, returns an array with all the results of the request that the user has sent (https://developers.google.com/api-client-library/php/guide/batch#handling-responses). I have thoughts about how to handle that but I would like feedback on this initial stage of the PR.

9) For info, in regards to point 8, if you supply an associated array to any of the methods, the key for the corresponding request is used in the response array so you can get your result very easily from the reply.


There's loads here to get used too. It's one of my first PR's so no doubt there's loads to be picked on, but I would appreciate any thoughts you might have.

Thank you.