### PR TITLE
Add orderBy parameter to sort all events chronologically by default

### DIFF
--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -32,7 +32,10 @@ class GoogleCalendar
      */
     public function listEvents(Carbon $startDateTime = null, Carbon $endDateTime = null, array $queryParameters = []): array
     {
-        $parameters = ['singleEvents' => true];
+        $parameters = [
+            'singleEvents' => true,
+            'orderBy' => 'startTime',
+        ];
 
         if (is_null($startDateTime)) {
             $startDateTime = Carbon::now()->startOfDay();


### PR DESCRIPTION
In the case of having multiple single and recurring events in one calendar, the default Google API sorting is not chronologically. So when you expect all events ordered by start date, which seems the most logical, it doesn't.

This is especially the case when the 'singleEvents' parameter is true. With this fix, every event is sorted chronologically.

See: https://developers.google.com/calendar/v3/reference/events/list

"The order of the events returned in the result. Optional. The default is an unspecified, stable order. 

Acceptable values are:
"startTime": Order by the start date/time (ascending). This is only available when querying single events (i.e. the parameter singleEvents is True)
"updated": Order by last modification time (ascending)."