### PR TITLE
add the possibility to impersonate a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ return [
      *  The id of the Google Calendar that will be used by default.
      */
     'calendar_id' => env('GOOGLE_CALENDAR_ID'),
+
+    /*
+     *  The email address of the user account to impersonate.
+     */
+    'user_to_impersonate' => env('GOOGLE_CALENDAR_IMPERSONATE'),
 ];
 
 ```
@@ -122,6 +127,8 @@ Now that everything is set up on the API site, we’ll need to configure some th
 Open up the “Calendar Details” tab to see the id of the calendar. You need to specify that id in the config file.
 
 ![6](https://spatie.github.io/laravel-google-calendar/v2/6.jpg)
+
+If you have delegated domain-wide access to the service account and you want to impersonate a user account, specify the email address of the user account in the config file.
 
 ## Usage
 

--- a/config/google-calendar.php
+++ b/config/google-calendar.php
@@ -11,4 +11,9 @@ return [
      *  The id of the Google Calendar that will be used by default.
      */
     'calendar_id' => env('GOOGLE_CALENDAR_ID'),
+
+    /*
+     *  The email address of the user account to impersonate.
+     */
+    'user_to_impersonate' => env('GOOGLE_CALENDAR_IMPERSONATE'),
 ];

--- a/src/GoogleCalendarFactory.php
+++ b/src/GoogleCalendarFactory.php
@@ -28,6 +28,10 @@ class GoogleCalendarFactory
 
         $client->setAuthConfig($config['service_account_credentials_json']);
 
+        if ($config['user_to_impersonate']) {
+            $client->setSubject($config['user_to_impersonate']);
+        }
+
         return $client;
     }
 


### PR DESCRIPTION
Hi,

This PR adds the possibility to impersonate a user when using Google API. It's  necessary when dealing with domain delegation (eg. when using G-Suite).

Source & reference: 
- https://developers.google.com/api-client-library/php/auth/service-accounts#delegatingauthority
- https://developers.google.com/identity/protocols/OAuth2ServiceAccount#delegatingauthority

I'm not sure how to test this, so if you got any lead lett me know.


