### PR TITLE
Add getter for calendar ID per event

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -182,6 +182,11 @@ class Event
         return '';
     }
 
+    public function getCalendarId(): string
+    {
+        return $this->calendarId;
+    }
+
     protected static function getGoogleCalendar(string $calendarId = null): GoogleCalendar
     {
         $calendarId = $calendarId ?? config('google-calendar.calendar_id');


### PR DESCRIPTION
This PR adds a getter for the calendar ID that is added [here](https://github.com/spatie/laravel-google-calendar/blob/master/src/Event.php#L56) but seemingly not accessible afterwards.
My use case is: I have multiple calendars, of which I get and merge the collections of Events. However, when displaying the data I would like to show the origin based on the calendar ID.