### PR TITLE
fixed fetching more than 250 results of calendar events

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -68,9 +68,19 @@ class Event
 
         $googleEvents = $googleCalendar->listEvents($startDateTime, $endDateTime, $queryParameters);
 
+        $googleEventsList = $googleEvents->getItems();
+
+        while($googleEvents->getNextPageToken()) {
+            $queryParameters['pageToken'] = $googleEvents->getNextPageToken();
+
+            $googleEvents = $googleCalendar->listEvents($startDateTime, $endDateTime, $queryParameters);
+
+            $googleEventsList = array_merge($googleEventsList, $googleEvents->getItems());
+        }
+
         $useUserOrder = isset($queryParameters['orderBy']);
 
-        return collect($googleEvents)
+        return collect($googleEventsList)
             ->map(function (Google_Service_Calendar_Event $event) use ($calendarId) {
                 return static::createFromGoogleCalendarEvent($event, $calendarId);
             })

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DateTime;
 use Google_Service_Calendar;
 use Google_Service_Calendar_Event;
+use Google_Service_Calendar_Events;
 
 class GoogleCalendar
 {
@@ -30,7 +31,7 @@ class GoogleCalendar
     /*
      * @link https://developers.google.com/google-apps/calendar/v3/reference/events/list
      */
-    public function listEvents(Carbon $startDateTime = null, Carbon $endDateTime = null, array $queryParameters = []): array
+    public function listEvents(Carbon $startDateTime = null, Carbon $endDateTime = null, array $queryParameters = []): Google_Service_Calendar_Events
     {
         $parameters = [
             'singleEvents' => true,
@@ -53,8 +54,7 @@ class GoogleCalendar
         return $this
             ->calendarService
             ->events
-            ->listEvents($this->calendarId, $parameters)
-            ->getItems();
+            ->listEvents($this->calendarId, $parameters);
     }
 
     public function getEvent(string $eventId): Google_Service_Calendar_Event


### PR DESCRIPTION
When specified calendar has more than 250 events (default value of maxResults parameter) rest of results are not included in Collection response. I've added support for using nextPageToken and pageToken parameters to include whole list of events even if they're exceeding 250 (or another maxResults limit).