### PR TITLE
Allow passing array of credentials.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 composer.lock
 vendor
+.idea

--- a/src/Exceptions/InvalidConfiguration.php
+++ b/src/Exceptions/InvalidConfiguration.php
@@ -15,4 +15,9 @@ class InvalidConfiguration extends Exception
     {
         return new static("Could not find a credentials file at `{$path}`.");
     }
+
+    public static function credentialsTypeWrong($credentials)
+    {
+        return new static(sprintf('Credentials should be an array or the path of json file. "%s was given.', gettype($credentials)));
+    }
 }

--- a/src/GoogleCalendarServiceProvider.php
+++ b/src/GoogleCalendarServiceProvider.php
@@ -35,8 +35,14 @@ class GoogleCalendarServiceProvider extends ServiceProvider
             throw InvalidConfiguration::calendarIdNotSpecified();
         }
 
-        if (! file_exists($config['service_account_credentials_json'])) {
-            throw InvalidConfiguration::credentialsJsonDoesNotExist($config['service_account_credentials_json']);
+        $credentials = $config['service_account_credentials_json'];
+
+        if (! is_array($credentials) && ! is_string($credentials)) {
+            throw InvalidConfiguration::credentialsTypeWrong($credentials);
+        }
+
+        if (is_string($credentials) && ! file_exists($credentials)) {
+            throw InvalidConfiguration::credentialsJsonDoesNotExist($credentials);
         }
     }
 }


### PR DESCRIPTION
Hi, 
Google allows passing an associative array of credentials instead of the path of the json file containing them.

See: https://github.com/googleapis/google-api-php-client/blob/afd3b55207efd691564c6e8e8b9e9bb39f6ce4f4/src/Google/Client.php#L900-L939

This PR allows it too in the Laravel config.

It especially allows to store the credentials in env, instead of file: 
```php
json_decode(env('GOOGLE_CALENDAR_CREDENTIALS'))
```

Thanks.