### PR TITLE
Enabling delegated domain-wide with impersonate user account

### DIFF
--- a/config/google-calendar.php
+++ b/config/google-calendar.php
@@ -11,4 +11,9 @@ return [
      *  The id of the Google Calendar that will be used by default.
      */
     'calendar_id' => env('GOOGLE_CALENDAR_ID'),
+
+    /*
+     *  The user e-mail of the Google Calendar that will be impersonated.
+     */
+	'user_to_impersonate' => env('USER_TO_IMPERSONATE'),
 ];

--- a/config/google-calendar.php
+++ b/config/google-calendar.php
@@ -15,5 +15,5 @@ return [
     /*
      *  The user e-mail of the Google Calendar that will be impersonated.
      */
-	'user_to_impersonate' => env('USER_TO_IMPERSONATE'),
+    'user_to_impersonate' => env('USER_TO_IMPERSONATE', ''),
 ];

--- a/src/GoogleCalendarFactory.php
+++ b/src/GoogleCalendarFactory.php
@@ -28,6 +28,8 @@ class GoogleCalendarFactory
 
         $client->setAuthConfig($config['service_account_credentials_json']);
 
+        $client->setSubject($config['user_to_impersonate']);
+
         return $client;
     }
 

--- a/src/GoogleCalendarFactory.php
+++ b/src/GoogleCalendarFactory.php
@@ -28,7 +28,9 @@ class GoogleCalendarFactory
 
         $client->setAuthConfig($config['service_account_credentials_json']);
 
-        $client->setSubject($config['user_to_impersonate']);
+        if ($config['user_to_impersonate'] == '') {
+            $client->setSubject($config['user_to_impersonate']);
+        }
 
         return $client;
     }


### PR DESCRIPTION
I have a problem described in #152 and I manage to solve reading the google-api-php-client docs in https://github.com/googleapis/google-api-php-client#authentication-with-service-accounts.

Don't know if is a feature that you want to provide in your package, but it was a necessity for me and I solve changing these two files. My intention was to enable to pass the `user_to_impersonate` variable at every request when you create an event for example, like you do in with `$calendarId`, but I couldn't, so my contribution is just this ;)

