### PR TITLE
Allow `CarbonImmutable` date

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -223,7 +223,7 @@ class Event
         return GoogleCalendarFactory::createForCalendarId($calendarId);
     }
 
-    protected function setDateProperty(string $name, Carbon $date)
+    protected function setDateProperty(string $name, CarbonInterface $date)
     {
         $eventDateTime = new Google_Service_Calendar_EventDateTime;
 


### PR DESCRIPTION
This pull request will allow to use `Carbon` or `CarbonImmutable` instance.

```php
use Carbon\Carbon;
use Carbon\CarbonImmutable;
use Spatie\GoogleCalendar\Event;

$event = new Event;

// Before: Only be able to assign Carbon instance.
$event->startDateTime = Carbon::now();

// After: Also be able to assign CarbonImmutable instance.
$event->startDateTime = CarbonImmutable::now();
```