### PR TITLE
Add support for OAuth2 authentication, source property on Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ Scroll down to the "Integrate calendar" section to see the id of the calendar. Y
 
 ![10](./docs/v2/10.png)
 
+### Authentication with OAuth2
+
+This package now supports OAuth2 authentication, allowing you to authenticate with an actual Google account. This makes it possible to create and manage events with your own Google account rather than a separate service account. This also enables you to use source urls in your events, which are only visible to the creator of the event (see [docs](https://developers.google.com/calendar/v3/reference/events) for more on the source property).
+
+OAuth2 authentication requires a token file, in addition to the credentials file. The easiest way to generate both of these files is by using the [php quickstart tool](https://developers.google.com/calendar/quickstart/php). Following this guide will generate two files, `credentials.json` and `token.json`. They must be saved to your project as `oauth-credentials.json` and `oauth-token.json`, respectively. Check the config file in this package for exact details on where to save these files.
+
+To use OAuth2, you must also set a new environment variable in your .env file:
+
+```php
+GOOGLE_CALENDAR_AUTH_PROFILE=oauth
+```
+
+If you are upgrading from an older version of this package, you will need to force a publish of the configuration:
+
+```bash
+php artisan vendor:publish --provider="Spatie\GoogleCalendar\GoogleCalendarServiceProvider" --force
+```
+
+Finally, for a more seamless experience in your application, instead of using the quickstart tool you can set up a consent screen in the [Google API console](https://console.developers.google.com/apis). This would allow non-technical users of your application to easily generate their own tokens. This is completely optional.
+
 ## Usage
 
 ### Getting events

--- a/config/google-calendar.php
+++ b/config/google-calendar.php
@@ -2,10 +2,35 @@
 
 return [
 
-    /*
-     * Path to the json file containing the credentials.
-     */
-    'service_account_credentials_json' => storage_path('app/google-calendar/service-account-credentials.json'),
+    'default_auth_profile' => env('GOOGLE_CALENDAR_AUTH_PROFILE', 'service_account'),
+
+    'auth_profiles' => [
+
+        /*
+         * Authenticate using a service account.
+         */
+        'service_account' => [
+            /*
+             * Path to the json file containing the credentials.
+             */
+            'credentials_json' => storage_path('app/google-calendar/service-account-credentials.json')
+        ],
+
+        /*
+         * Authenticate with actual google user account.
+         */
+        'oauth' => [
+            /*
+             * Path to the json file containing the oauth2 credentials.
+             */
+            'credentials_json' => storage_path('app/google-calendar/oauth-credentials.json'),
+
+            /*
+             * Path to the json file containing the oauth2 token.
+             */
+            'token_json' => storage_path('app/google-calendar/oauth-token.json')
+        ]
+    ],
 
     /*
      *  The id of the Google Calendar that will be used by default.

--- a/src/Event.php
+++ b/src/Event.php
@@ -121,6 +121,13 @@ class Event
             return $this->getSortDate();
         }
 
+        if ($name === 'source') {
+            return array([
+                'title' => $this->googleEvent->getSource()->title,
+                'url' => $this->googleEvent->getSource()->url
+            ]);
+        }
+
         $value = Arr::get($this->googleEvent, $name);
 
         if (in_array($name, ['start.date', 'end.date']) && $value) {
@@ -140,6 +147,12 @@ class Event
 
         if (in_array($name, ['start.date', 'end.date', 'start.dateTime', 'end.dateTime'])) {
             $this->setDateProperty($name, $value);
+
+            return;
+        }
+
+        if ($name == 'source') {
+            $this->setSourceProperty($value);
 
             return;
         }
@@ -244,6 +257,16 @@ class Event
         if (Str::startsWith($name, 'end')) {
             $this->googleEvent->setEnd($eventDateTime);
         }
+    }
+
+    protected function setSourceProperty(array $value)
+    {
+        $source = new \Google_Service_Calendar_EventSource([
+            'title' => $value['title'],
+            'url' => $value['url']
+        ]);
+
+        $this->googleEvent->setSource($source);
     }
 
     protected function getFieldName(string $name): string

--- a/src/GoogleCalendarFactory.php
+++ b/src/GoogleCalendarFactory.php
@@ -20,16 +20,46 @@ class GoogleCalendarFactory
 
     public static function createAuthenticatedGoogleClient(array $config): Google_Client
     {
+        $authProfile = $config['default_auth_profile'];
+
+        switch($authProfile) {
+            case 'service_account':
+                return self::createServiceAccountClient($config['auth_profiles']['service_account']);
+            case 'oauth':
+                return self::createOAuthClient($config['auth_profiles']['oauth']);
+        }
+
+        throw new \InvalidArgumentException("Unsupported authentication profile [{$authProfile}].");
+    }
+
+    protected static function createServiceAccountClient(array $authProfile): Google_Client
+    {
         $client = new Google_Client;
 
         $client->setScopes([
             Google_Service_Calendar::CALENDAR,
         ]);
 
-        $client->setAuthConfig($config['service_account_credentials_json']);
+        $client->setAuthConfig($authProfile['credentials_json']);
 
         return $client;
     }
+
+    protected static function createOAuthClient(array $authProfile): Google_Client
+    {
+        $client = new Google_Client;
+
+        $client->setScopes([
+            Google_Service_Calendar::CALENDAR,
+        ]);
+
+        $client->setAuthConfig($authProfile['credentials_json']);
+
+        $client->setAccessToken(file_get_contents($authProfile['token_json']));
+
+        return $client;
+    }
+
 
     protected static function createCalendarClient(Google_Service_Calendar $service, string $calendarId): GoogleCalendar
     {

--- a/src/GoogleCalendarServiceProvider.php
+++ b/src/GoogleCalendarServiceProvider.php
@@ -35,14 +35,46 @@ class GoogleCalendarServiceProvider extends ServiceProvider
             throw InvalidConfiguration::calendarIdNotSpecified();
         }
 
-        $credentials = $config['service_account_credentials_json'];
+        $authProfile = $config['default_auth_profile'];
 
-        if (! is_array($credentials) && ! is_string($credentials)) {
-            throw InvalidConfiguration::credentialsTypeWrong($credentials);
+        switch ($authProfile) {
+            case 'service_account':
+                $this->validateServiceAccountConfigSettings($config);
+                break;
+            case 'oauth':
+                $this->validateOAuthConfigSettings($config);
+                break;
+            default:
+                throw new \InvalidArgumentException("Unsupported authentication profile [{$authProfile}].");
+        }
+    }
+
+    protected function validateServiceAccountConfigSettings(array $config = null)
+    {
+        $credentials = $config['auth_profiles']['service_account']['credentials_json'];
+
+        $this->validateConfigSetting($credentials);
+    }
+
+    protected function validateOAuthConfigSettings(array $config = null)
+    {
+        $credentials = $config['auth_profiles']['oauth']['credentials_json'];
+
+        $this->validateConfigSetting($credentials);
+
+        $token = $config['auth_profiles']['oauth']['token_json'];
+
+        $this->validateConfigSetting($token);
+    }
+
+    protected function validateConfigSetting(string $setting)
+    {
+        if (! is_array($setting) && ! is_string($setting)) {
+            throw InvalidConfiguration::credentialsTypeWrong($setting);
         }
 
-        if (is_string($credentials) && ! file_exists($credentials)) {
-            throw InvalidConfiguration::credentialsJsonDoesNotExist($credentials);
+        if (is_string($setting) && ! file_exists($setting)) {
+            throw InvalidConfiguration::credentialsJsonDoesNotExist($setting);
         }
     }
 }

--- a/tests/Integration/EventTest.php
+++ b/tests/Integration/EventTest.php
@@ -101,6 +101,18 @@ class EventTest extends TestCase
     }
 
     /** @test */
+    public function it_can_set_a_source()
+    {
+        $this->event->source = array(
+            'title' => 'Test Source Title',
+            'url' => 'http://testsource.url'
+        );
+
+        $this->assertEquals('Test Source Title', $this->event->googleEvent->getSource()->title);
+        $this->assertEquals('http://testsource.url', $this->event->googleEvent->getSource()->url);
+    }
+
+    /** @test */
     public function it_can_determine_if_an_event_is_an_all_day_event()
     {
         $event = new Event;


### PR DESCRIPTION
Thanks for this awesome project! I needed some new features and I thought they were worth sharing with the community.

### New features:
* Authenticate using OAuth2 as an alternative to using service accounts
* Add getter/setter for the `source` property on Events (also added a test for this)

### Background:

![Uploading Capture.PNG…]()

The `source` property on the google event object allows you to set a custom url as an attribute in the calendar event. The link is visible and clickable in the Google Calendar interface. While the `source` property was accessible via `$event->googleEvent->getSource()` and `$event->googleEvent->setSource()`, it was not working when authenticating with a service account.

A closer look at the [api documentation](https://developers.google.com/calendar/v3/reference/events) reveals the problem:
> Source from which the event was created. For example, a web page, an email message or any document identifiable by an URL with HTTP or HTTPS scheme. **Can only be seen or modified by the creator of the event.**

This means that only the user who created the event can see the link, i.e. the link is only visible to the service account user. This is why I forked to add support for authenticating using my own Google account.

### Implementation:

The new authentication method can be configured by setting a new environment variable, `GOOGLE_CALENDAR_AUTH_PROFILE`. Setting this variable to `oauth` will select the OAuth2 profile. The config will default to using the service account if you do not set anything. The code will switch to authenticate the client based on the selected profile. I have included instructions for obtaining the OAuth2 credentials in the README.

The new getter/setter for the Event `source` property can be used no matter how you authenticate, but it will only be readable by the creator of the event.

### Upgrading:

Due to changes in the config file, if you upgrade from an older version you will have to publish a fresh config. I have included a note about this in the readme.