### PR TITLE
Add correct contents of config file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,36 @@ php artisan vendor:publish --provider="Spatie\GoogleCalendar\GoogleCalendarServi
 This will publish a file called `google-calendar.php` in your config-directory with these contents:
 ```
 return [
-    /*
-     * Path to the json file containing the credentials.
-     */
-    'service_account_credentials_json' => storage_path('app/google-calendar/service-account-credentials.json'),
+
+    'default_auth_profile' => env('GOOGLE_CALENDAR_AUTH_PROFILE', 'service_account'),
+
+    'auth_profiles' => [
+
+        /*
+         * Authenticate using a service account.
+         */
+        'service_account' => [
+            /*
+             * Path to the json file containing the credentials.
+             */
+            'credentials_json' => storage_path('app/google-calendar/service-account-credentials.json'),
+        ],
+
+        /*
+         * Authenticate with actual google user account.
+         */
+        'oauth' => [
+            /*
+             * Path to the json file containing the oauth2 credentials.
+             */
+            'credentials_json' => storage_path('app/google-calendar/oauth-credentials.json'),
+
+            /*
+             * Path to the json file containing the oauth2 token.
+             */
+            'token_json' => storage_path('app/google-calendar/oauth-token.json'),
+        ],
+    ],
 
     /*
      *  The id of the Google Calendar that will be used by default.


### PR DESCRIPTION
There was a recent change that updated the values of the config file, which was listed here in the README. I've updated it to reflect the updated config file. Here's the commit where the config was changed.

https://github.com/spatie/laravel-google-calendar/commit/ea4faf224b3259ed36a9f7129e9cd5ad2030fea4