### PR TITLE
Allow user to pass in optional parameters to updateEvent

### DIFF
--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -83,13 +83,13 @@ class GoogleCalendar
         return $this->calendarService->events->quickAdd($this->calendarId, $event);
     }
 
-    public function updateEvent($event): Google_Service_Calendar_Event
+    public function updateEvent($event, $optParams = []): Google_Service_Calendar_Event
     {
         if ($event instanceof Event) {
             $event = $event->googleEvent;
         }
 
-        return $this->calendarService->events->update($this->calendarId, $event->id, $event);
+        return $this->calendarService->events->update($this->calendarId, $event->id, $event, $optParams);
     }
 
     public function deleteEvent($eventId)


### PR DESCRIPTION
This will allow you to add optional parameters when updating an event. In particular, when saving an event like so:

```php
$event->save(null, ['sendUpdates' => 'all']);
```

This will now pass in the optional parameters and send updates on both create AND edit.