### PR TITLE
Allow Optional Parameters on Delete

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -201,9 +201,9 @@ class Event
         return $this->save('updateEvent', $optParams);
     }
 
-    public function delete(string $eventId = null)
+    public function delete(string $eventId = null, $optParams = [])
     {
-        $this->getGoogleCalendar($this->calendarId)->deleteEvent($eventId ?? $this->id);
+        $this->getGoogleCalendar($this->calendarId)->deleteEvent($eventId ?? $this->id, $optParams);
     }
 
     public function addAttendee(array $attendee)

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -92,13 +92,13 @@ class GoogleCalendar
         return $this->calendarService->events->update($this->calendarId, $event->id, $event, $optParams);
     }
 
-    public function deleteEvent($eventId)
+    public function deleteEvent($eventId, $optParams = [])
     {
         if ($eventId instanceof Event) {
             $eventId = $eventId->id;
         }
 
-        $this->calendarService->events->delete($this->calendarId, $eventId);
+        $this->calendarService->events->delete($this->calendarId, $eventId, $optParams);
     }
 
     public function getService(): Google_Service_Calendar


### PR DESCRIPTION
When deleting an event, the user may want to send through optional parameters to the Google API.

With this update, a user can now do this:

```php
$event = Event::find('google_event_id', 'organizer@email.com');

$event->delete(null, ['sendUpdates' => 'all']);
```