### PR TITLE
Fix timezone that is not properly set

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -248,12 +248,12 @@ class Event
 
         if (in_array($name, ['start.date', 'end.date'])) {
             $eventDateTime->setDate($date->format('Y-m-d'));
-            $eventDateTime->setTimezone($date->getTimezone());
+            $eventDateTime->setTimezone((string) $date->getTimezone());
         }
 
         if (in_array($name, ['start.dateTime', 'end.dateTime'])) {
             $eventDateTime->setDateTime($date->format(DateTime::RFC3339));
-            $eventDateTime->setTimezone($date->getTimezone());
+            $eventDateTime->setTimezone((string) $date->getTimezone());
         }
 
         if (Str::startsWith($name, 'start')) {

--- a/tests/Integration/EventTest.php
+++ b/tests/Integration/EventTest.php
@@ -166,4 +166,14 @@ class EventTest extends TestCase
 
         $event::quickCreate('Appointment at Somewhere on April 25 10am-10:25am');
     }
+
+    /** @test */
+    public function it_can_set_a_timezone_that_is_a_string()
+    {
+        $now = Carbon::now()->setTimezone('Indian/Reunion');
+
+        $this->event->endDateTime = $now;
+
+        $this->assertEquals((string) $now->getTimezone(), 'Indian/Reunion');
+    }
 }


### PR DESCRIPTION
Fixes: #231

This fix casts the timezone to a string when setting the timezone so that it is compatible with Google Calendar API specifications:
https://developers.google.com/calendar/api/v3/reference/events/insert\#end.timeZone