### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4, 7.3, 7.2]
+                php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2]
                 laravel: [9.*, 8.*, 6.*, 7.*]
                 dependency-version: [prefer-stable]
                 include:
@@ -50,7 +50,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,6 +23,10 @@ jobs:
                         testbench: 4.*
                 exclude:
                     -   laravel: 6.*
+                        php: 8.2
+                    -   laravel: 7.*
+                        php: 8.2
+                    -   laravel: 6.*
                         php: 8.1
                     -   laravel: 7.*
                         php: 8.1

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2|^8.0",
         "google/apiclient": "^2.2",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "nesbot/carbon": "^2.0"
+        "nesbot/carbon": "^2.63"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3|^1.4",


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.

It also bumps the required minimum version for nesbot/carbon.

_id:php82-support/v1.0_