### PR TITLE
Update phpunit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 .idea
 .php-cs-fixer.cache
+.phpunit.cache

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="true"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Spatie Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
Currently the PHPUnit config is using a deprecated format.

Ran the configuration migration command

```sh
./vendor/bin/phpunit --migrate-configuration
```

Also added the result cache to gitignore.

## Before
![CleanShot 2024-11-03 at 14 47 54@2x](https://github.com/user-attachments/assets/7864f340-eec6-434e-a613-c18ee3e26817)

## After
![CleanShot 2024-11-03 at 14 49 06@2x](https://github.com/user-attachments/assets/f91742d8-fc40-4849-8d84-83878d05d567)
