### PR TITLE
Adding null typing to solve php 8.4 depreciation.

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -80,7 +80,7 @@ class Event
         return $event->quickSave($text);
     }
 
-    public static function get(?CarbonInterface $startDateTime = null, CarbonInterface $endDateTime = null, array $queryParameters = [], string $calendarId = null): Collection
+    public static function get(?CarbonInterface $startDateTime = null, ?CarbonInterface $endDateTime = null, array $queryParameters = [], string $calendarId = null): Collection
     {
         $googleCalendar = static::getGoogleCalendar($calendarId);
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -58,7 +58,7 @@ class Event
      *
      * @return mixed
      */
-    public static function create(array $properties, string $calendarId = null, $optParams = [])
+    public static function create(array $properties, ?string $calendarId = null, $optParams = [])
     {
         $event = new static;
 
@@ -80,7 +80,7 @@ class Event
         return $event->quickSave($text);
     }
 
-    public static function get(CarbonInterface $startDateTime = null, CarbonInterface $endDateTime = null, array $queryParameters = [], string $calendarId = null): Collection
+    public static function get(?CarbonInterface $startDateTime = null, CarbonInterface $endDateTime = null, array $queryParameters = [], string $calendarId = null): Collection
     {
         $googleCalendar = static::getGoogleCalendar($calendarId);
 
@@ -112,7 +112,7 @@ class Event
             ->values();
     }
 
-    public static function find($eventId, string $calendarId = null): self
+    public static function find($eventId, ?string $calendarId = null): self
     {
         $googleCalendar = static::getGoogleCalendar($calendarId);
 
@@ -178,7 +178,7 @@ class Event
         return is_null($this->googleEvent['start']['dateTime']);
     }
 
-    public function save(string $method = null, $optParams = []): self
+    public function save(?string $method = null, $optParams = []): self
     {
         $method = $method ?? ($this->exists() ? 'updateEvent' : 'insertEvent');
 
@@ -211,7 +211,7 @@ class Event
         return $this->save('updateEvent', $optParams);
     }
 
-    public function delete(string $eventId = null, $optParams = [])
+    public function delete(?string $eventId = null, $optParams = [])
     {
         $this->getGoogleCalendar($this->calendarId)->deleteEvent($eventId ?? $this->id, $optParams);
     }
@@ -262,7 +262,7 @@ class Event
         return $this->calendarId;
     }
 
-    protected static function getGoogleCalendar(string $calendarId = null): GoogleCalendar
+    protected static function getGoogleCalendar(?string $calendarId = null): GoogleCalendar
     {
         $calendarId = $calendarId ?? config('google-calendar.calendar_id');
 

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -32,7 +32,7 @@ class GoogleCalendar
     /*
      * @link https://developers.google.com/google-apps/calendar/v3/reference/events/list
      */
-    public function listEvents(?CarbonInterface $startDateTime = null, CarbonInterface $endDateTime = null, array $queryParameters = []): Google_Service_Calendar_Events
+    public function listEvents(?CarbonInterface $startDateTime = null, ?CarbonInterface $endDateTime = null, array $queryParameters = []): Google_Service_Calendar_Events
     {
         $parameters = [
             'singleEvents' => true,

--- a/src/GoogleCalendar.php
+++ b/src/GoogleCalendar.php
@@ -32,7 +32,7 @@ class GoogleCalendar
     /*
      * @link https://developers.google.com/google-apps/calendar/v3/reference/events/list
      */
-    public function listEvents(CarbonInterface $startDateTime = null, CarbonInterface $endDateTime = null, array $queryParameters = []): Google_Service_Calendar_Events
+    public function listEvents(?CarbonInterface $startDateTime = null, CarbonInterface $endDateTime = null, array $queryParameters = []): Google_Service_Calendar_Events
     {
         $parameters = [
             'singleEvents' => true,

--- a/src/GoogleCalendarServiceProvider.php
+++ b/src/GoogleCalendarServiceProvider.php
@@ -29,7 +29,7 @@ class GoogleCalendarServiceProvider extends ServiceProvider
         $this->app->alias(GoogleCalendar::class, 'laravel-google-calendar');
     }
 
-    protected function guardAgainstInvalidConfiguration(array $config = null)
+    protected function guardAgainstInvalidConfiguration(?array $config = null)
     {
         if (empty($config['calendar_id'])) {
             throw InvalidConfiguration::calendarIdNotSpecified();
@@ -52,14 +52,14 @@ class GoogleCalendarServiceProvider extends ServiceProvider
         throw InvalidConfiguration::invalidAuthenticationProfile($authProfile);
     }
 
-    protected function validateServiceAccountConfigSettings(array $config = null)
+    protected function validateServiceAccountConfigSettings(?array $config = null)
     {
         $credentials = $config['auth_profiles']['service_account']['credentials_json'];
 
         $this->validateConfigSetting($credentials);
     }
 
-    protected function validateOAuthConfigSettings(array $config = null)
+    protected function validateOAuthConfigSettings(?array $config = null)
     {
         $credentials = $config['auth_profiles']['oauth']['credentials_json'];
 


### PR DESCRIPTION
In the last PHP update to version 8.4, the declaration of variables initialized as null without proper typing was deprecated.

https://www.php.net/manual/en/migration84.deprecated.php

![image](https://github.com/user-attachments/assets/80bcee65-e534-4eae-b0b8-d9d7e991c2bc)


This MR intends to resolve the warning alerts presented for the package within the applications that use it.

![Screenshot from 2025-01-23 11-55-08](https://github.com/user-attachments/assets/254c74ac-0b33-48cb-96f6-dfbc32b4fde3)
