### PR TITLE
Adding null typing to solve (latest) php 8.4 deprecation

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -80,7 +80,7 @@ class Event
         return $event->quickSave($text);
     }
 
-    public static function get(?CarbonInterface $startDateTime = null, ?CarbonInterface $endDateTime = null, array $queryParameters = [], string $calendarId = null): Collection
+    public static function get(?CarbonInterface $startDateTime = null, ?CarbonInterface $endDateTime = null, array $queryParameters = [], ?string $calendarId = null): Collection
     {
         $googleCalendar = static::getGoogleCalendar($calendarId);
 


### PR DESCRIPTION
Following PR #303 
> In the last PHP update to version 8.4, the declaration of variables initialized as null without proper typing was deprecated.

https://www.php.net/manual/en/migration84.deprecated.php

This PR intends to resolve the **latest** warning alert presented for the package within applications that use it.

> Deprecated: Spatie\GoogleCalendar\Event::get(): Implicitly marking parameter $calendarId as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/spatie/laravel-google-calendar/src/Event.php on line 83