### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0, 7.4, 7.3, 7.2]
+        php: [8.5, 8.2, 8.1, 8.0, 7.4, 7.3, 7.2]
         laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*', '12.*']
         dependency-version: [prefer-stable]
         include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,98 +1,49 @@
 name: run-tests
 
-on:
-  - push
-  - pull_request
+on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        php: [8.5, 8.2, 8.1, 8.0, 7.4, 7.3, 7.2]
-        laravel: ['6.*', '7.*', '8.*', '9.*', '10.*', '11.*', '12.*']
-        dependency-version: [prefer-stable]
+        php: [8.5, 8.4, 8.3, 8.2]
+        laravel: ['13.*', '12.*', '11.*', '10.*']
+        stability: [prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-          - laravel: 9.*
-            testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
-          - laravel: 6.*
-            testbench: 4.*
-          - laravel: 11.*
-            testbench: 9.*
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 10.*
+            testbench: 8.*
         exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 10.*
-            php: 7.4
-          - laravel: 10.*
-            php: 7.3
-          - laravel: 10.*
-            php: 7.2
-          - laravel: 6.*
+          - laravel: 13.*
             php: 8.2
-          - laravel: 7.*
-            php: 8.2
-          - laravel: 6.*
-            php: 8.1
-          - laravel: 7.*
-            php: 8.1
-          - laravel: 8.*
-            php: 7.2
-          - laravel: 9.*
-            php: 7.4
-          - laravel: 9.*
-            php: 7.3
-          - laravel: 9.*
-            php: 7.2
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 7.4
-          - laravel: 11.*
-            php: 7.3
-          - laravel: 11.*
-            php: 7.2
-          - laravel: 12.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.0
-          - laravel: 12.*
-            php: 7.4
-          - laravel: 12.*
-            php: 7.3
-          - laravel: 12.*
-            php: 7.2
+          - laravel: 10.*
+            php: 8.5
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^7.2|^8.0",
         "google/apiclient": "^2.2",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "nesbot/carbon": "^2.63|^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3|^1.4",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^8.4|^9.0|^10.5|^11.5.3"
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "phpunit/phpunit": "^8.4|^9.0|^10.5|^11.5.3|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Integration/EventTest.php
+++ b/tests/Integration/EventTest.php
@@ -7,6 +7,7 @@ use DateTime;
 use Mockery as m;
 use Spatie\GoogleCalendar\Event;
 use Spatie\GoogleCalendar\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class EventTest extends TestCase
 {
@@ -20,7 +21,7 @@ class EventTest extends TestCase
         $this->event = new Event;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_start_date()
     {
         $now = Carbon::now();
@@ -32,7 +33,7 @@ class EventTest extends TestCase
         $this->assertEquals($now, $this->event->startDate);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_end_date()
     {
         $now = Carbon::now();
@@ -42,7 +43,7 @@ class EventTest extends TestCase
         $this->assertEquals($now->format('Y-m-d'), $this->event->googleEvent['end']['date']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_start_date_time()
     {
         $now = Carbon::now();
@@ -52,7 +53,7 @@ class EventTest extends TestCase
         $this->assertEquals($now->format(DateTime::RFC3339), $this->event->googleEvent['start']['dateTime']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_an_end_date_time()
     {
         $now = Carbon::now();
@@ -62,7 +63,7 @@ class EventTest extends TestCase
         $this->assertEquals($now->format(DateTime::RFC3339), $this->event->googleEvent['end']['dateTime']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_determine_a_sort_date()
     {
         $now = Carbon::now();
@@ -76,7 +77,7 @@ class EventTest extends TestCase
         $this->assertEquals($now, $event->getSortDate());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_name()
     {
         $this->event->name = 'testname';
@@ -84,7 +85,7 @@ class EventTest extends TestCase
         $this->assertEquals('testname', $this->event->googleEvent['summary']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_color()
     {
         $this->event->googleEvent->setColorId(11);
@@ -92,7 +93,7 @@ class EventTest extends TestCase
         $this->assertEquals(11, $this->event->googleEvent['colorId']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_description()
     {
         $this->event->description = 'Test Description';
@@ -100,7 +101,7 @@ class EventTest extends TestCase
         $this->assertEquals('Test Description', $this->event->googleEvent['description']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_location()
     {
         $this->event->location = 'Test Location';
@@ -108,7 +109,7 @@ class EventTest extends TestCase
         $this->assertEquals('Test Location', $this->event->googleEvent->getLocation());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_source()
     {
         $this->event->source = [
@@ -120,7 +121,7 @@ class EventTest extends TestCase
         $this->assertEquals('http://testsource.url', $this->event->googleEvent->getSource()->url);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_multiple_attendees()
     {
         $attendees = [
@@ -143,7 +144,7 @@ class EventTest extends TestCase
         $this->assertEquals($attendees[1]['email'], $this->event->googleEvent->getAttendees()[1]->getEmail());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_meet_link()
     {
         $this->event->addMeetLink();
@@ -152,7 +153,7 @@ class EventTest extends TestCase
         $this->assertEquals('hangoutsMeet', $this->event->googleEvent->getConferenceData()->getCreateRequest()->getConferenceSolutionKey()->getType());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_determine_if_an_event_is_an_all_day_event()
     {
         $event = new Event;
@@ -166,7 +167,7 @@ class EventTest extends TestCase
         $this->assertFalse($event->isAllDayEvent());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_an_event_based_on_a_text_string()
     {
         $event = m::mock(Event::class);
@@ -175,7 +176,7 @@ class EventTest extends TestCase
         $event->quickSave('Appointment at Somewhere on April 25 10am-10:25am');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_an_event_based_on_a_text_string_statically()
     {
         $event = m::mock(Event::class);
@@ -184,7 +185,7 @@ class EventTest extends TestCase
         $event::quickCreate('Appointment at Somewhere on April 25 10am-10:25am');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_a_timezone_that_is_a_string()
     {
         $now = Carbon::now()->setTimezone('Indian/Reunion');

--- a/tests/Integration/EventTest.php
+++ b/tests/Integration/EventTest.php
@@ -5,9 +5,9 @@ namespace Spatie\GoogleCalendar\Tests\Integration;
 use Carbon\Carbon;
 use DateTime;
 use Mockery as m;
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\GoogleCalendar\Event;
 use Spatie\GoogleCalendar\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 class EventTest extends TestCase
 {

--- a/tests/Unit/GoogleCalendarTest.php
+++ b/tests/Unit/GoogleCalendarTest.php
@@ -6,6 +6,7 @@ use Google_Service_Calendar;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Spatie\GoogleCalendar\GoogleCalendar;
+use PHPUnit\Framework\Attributes\Test;
 
 class GoogleCalendarTest extends TestCase
 {
@@ -29,7 +30,7 @@ class GoogleCalendarTest extends TestCase
         $this->googleCalendar = new GoogleCalendar($this->googleServiceCalendar, $this->calendarId);
     }
 
-    /** @test */
+    #[Test]
     public function it_provides_a_getter_for_calendarId()
     {
         $this->assertEquals($this->calendarId, $this->googleCalendar->getCalendarId());

--- a/tests/Unit/GoogleCalendarTest.php
+++ b/tests/Unit/GoogleCalendarTest.php
@@ -4,9 +4,9 @@ namespace Spatie\GoogleCalendar\Tests\Unit;
 
 use Google_Service_Calendar;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Spatie\GoogleCalendar\GoogleCalendar;
-use PHPUnit\Framework\Attributes\Test;
 
 class GoogleCalendarTest extends TestCase
 {


### PR DESCRIPTION
## Summary
- Add Laravel 13 support
- Add PHP 8.5 to test matrix
- Fix coverage warnings
- Update test dependencies (Pest 4, PHPUnit 12, Testbench 11)